### PR TITLE
[win32] fix building because libXBMC_addon.h from kodi dependes on dlfcn-win32.h from kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,17 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(kodi REQUIRED)
+find_package(kodiplatform REQUIRED)
 
-include_directories(${KODI_INCLUDE_DIR}
+include_directories(${kodiplatform_INCLUDE_DIRS}
+                    ${KODI_INCLUDE_DIR}
                     ${PROJECT_SOURCE_DIR}/lib/snes_spc)
 
 add_subdirectory(lib/snes_spc)
 
 set(SNES_SOURCES src/SPCCodec.cpp)
 
-set(DEPLIBS snes_spc)
+set(DEPLIBS ${kodiplatform_LIBRARIES} snes_spc)
 
 build_addon(audiodecoder.snesapu SNES DEPLIBS)
 


### PR DESCRIPTION
This fix to get it building on win32 is simply but it's kinda nasty. `libXBMC_addon.h` which is part of the `kodi` header package depends on `dlfcn-win32.h` which is only provided with `kodi-platform`. But we currently don't define this dependency but we "build" both dependencies for all binary addons anyway.