### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,8 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${KODI_INCLUDE_DIR}/..
+include_directories(${KODI_INCLUDE_DIR}/..
                     ${PROJECT_SOURCE_DIR}/lib/snes_spc)
 
 add_subdirectory(lib/snes_spc)

--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,7 @@
 Source: kodi-audiodecoder-snesapu
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev,
-               libkodiplatform-dev (>= 16.0.0)
+Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev
 Standards-Version: 3.9.2
 Section: libs
 


### PR DESCRIPTION
The audiodecoder.snesapu binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.