### PR TITLE
rework to allow spc files within packaged rsn file

### DIFF
--- a/audiodecoder.snesapu/addon.xml.in
+++ b/audiodecoder.snesapu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.snesapu"
-  version="3.0.0"
+  version="19.0.0"
   name="SPC Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@

--- a/audiodecoder.snesapu/addon.xml.in
+++ b/audiodecoder.snesapu/addon.xml.in
@@ -4,12 +4,15 @@
   version="3.0.0"
   name="SPC Audio Decoder"
   provider-name="spiff">
-  <requires>@ADDON_DEPENDS@</requires>
+  <requires>@ADDON_DEPENDS@
+    <import addon="vfs.rar" minversion="4.0.0" optional="true"/>
+  </requires>
   <extension
     point="kodi.audiodecoder"
     name="spc"
-    extension=".spc"
+    extension=".spc|.spcstream|.rsn"
     tags="true"
+    tracks="true"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <platform>@PLATFORM@</platform>

--- a/audiodecoder.snesapu/resources/language/resource.language.en_gb/strings.po
+++ b/audiodecoder.snesapu/resources/language/resource.language.en_gb/strings.po
@@ -23,3 +23,9 @@ msgstr ""
 msgctxt "Addon Description"
 msgid "The SPC format holds Super Nintendo (SNES) game music. It is named after Sony's SPC700 contribution to the SNES's S-SMP audio chip. The SNES was a major jump in audio technology from the NES allowing for stereo sound, more channels, and fully sampled instruments."
 msgstr ""
+
+#. Genre type of played game sound file
+#: src/SPCCodec.cpp
+msgctxt "#30100"
+msgid "Voice/Speech"
+msgstr ""

--- a/src/SPCCodec.cpp
+++ b/src/SPCCodec.cpp
@@ -9,6 +9,7 @@
 
 #include <cctype>
 #include <kodi/Filesystem.h>
+#include <kodi/General.h>
 #include <kodi/tools/StringUtils.h>
 #include <unordered_set>
 
@@ -183,7 +184,10 @@ bool CSPCCodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderIn
         if (last_index != std::string::npos)
         {
           if (filename.substr(last_index - 1)[0] == '-' && !isdigit(filename.substr(last_index)[0]))
+          {
             section = filename.substr(last_index)[0];
+            tag.SetGenre(GetGenre(section));
+          }
           track = atoi(filename.substr(last_index + 1).c_str());
         }
         check_at_end = true;
@@ -303,6 +307,19 @@ int CSPCCodec::GetTrackNumber(std::string& toLoad)
     toLoad = toLoad.substr(0, slash);
   }
   return track;
+}
+
+std::string CSPCCodec::GetGenre(char idChar)
+{
+  switch (idChar)
+  {
+    case 'v':
+      return kodi::GetLocalizedString(30100);
+    default:
+      break;
+  }
+
+  return "";
 }
 
 std::string CSPCCodec::URLEncode(const std::string& strURLData)

--- a/src/SPCCodec.cpp
+++ b/src/SPCCodec.cpp
@@ -7,13 +7,18 @@
 
 #include "SPCCodec.h"
 
+#include <cctype>
 #include <kodi/Filesystem.h>
+#include <kodi/tools/StringUtils.h>
+#include <unordered_set>
 
 //------------------------------------------------------------------------------
 
 #define SPC_CHANNELS 2
 #define SPC_SAMPLERATE 32000
 #define SPC_BITSPERSAMPLE 16
+
+#define MAX_PATH_LENGTH 2048
 
 CSPCCodec::CSPCCodec(KODI_HANDLE instance, const std::string& version)
   : CInstanceAudioDecoder(instance, version)
@@ -37,8 +42,24 @@ bool CSPCCodec::Init(const std::string& filename,
                      AudioEngineDataFormat& format,
                      std::vector<AudioEngineChannel>& channellist)
 {
+  std::string toLoad(filename);
+  int track = GetTrackNumber(toLoad);
+
+  if (kodi::tools::StringUtils::EndsWith(filename, ".spcstream"))
+  {
+    std::vector<kodi::vfs::CDirEntry> items;
+    if (kodi::vfs::GetDirectory("rar://" + URLEncode(toLoad) + "/", ".spc", items))
+    {
+      toLoad = items[track].Path();
+    }
+    else
+    {
+      return false;
+    }
+  }
+
   kodi::vfs::CFile file;
-  if (!file.OpenFile(filename, 0))
+  if (!file.OpenFile(toLoad, 0))
     return false;
 
   ctx.song = spc_new();
@@ -55,7 +76,7 @@ bool CSPCCodec::Init(const std::string& filename,
   {
     kodi::Log(ADDON_LOG_WARNING,
               "Failed to parse tag information to get play length on '%s', using 4 minutes",
-              filename.c_str());
+              toLoad.c_str());
     ctx.tag.play_len = 4 * 60;
   }
 
@@ -101,8 +122,19 @@ int64_t CSPCCodec::Seek(int64_t time)
 
 bool CSPCCodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderInfoTag& tag)
 {
+  std::string toLoad(filename);
+  int track = GetTrackNumber(toLoad);
+  bool isRSNBaseRead = kodi::tools::StringUtils::EndsWith(filename, ".rsn");
+  std::vector<kodi::vfs::CDirEntry> items;
+
+  if (kodi::tools::StringUtils::EndsWith(filename, ".spcstream") || isRSNBaseRead)
+  {
+    if (kodi::vfs::GetDirectory("rar://" + URLEncode(toLoad) + "/", ".spc", items))
+      toLoad = items[track].Path();
+  }
+
   kodi::vfs::CFile file;
-  if (!file.OpenFile(filename, 0))
+  if (!file.OpenFile(toLoad, 0))
     return false;
 
   int len = file.GetLength();
@@ -117,21 +149,187 @@ bool CSPCCodec::ReadTag(const std::string& filename, kodi::addon::AudioDecoderIn
   if (id666_parse(&spcTag, data, len) != 0)
     return false;
 
-  tag.SetArtist(spcTag.artist);
+  if (!isRSNBaseRead)
+  {
+    tag.SetArtist(spcTag.artist);
+    tag.SetTitle(spcTag.song);
+    tag.SetDuration(spcTag.play_len / SPC_SAMPLERATE / SPC_CHANNELS);
+    tag.SetDisc(spcTag.ost_disc);
+    tag.SetTrack(spcTag.ost_track);
+    tag.SetComment(spcTag.comment);
+    tag.SetSamplerate(SPC_SAMPLERATE);
+    tag.SetChannels(SPC_CHANNELS);
+
+    if (spcTag.ost_track > 0)
+    {
+      tag.SetTrack(spcTag.ost_track);
+    }
+    else
+    {
+      // If track number was not present, check related folder contains only
+      // numbered files and no number more as one time inside.
+      //
+      // Mostly all files where I found for tests, was with a sort number on
+      // begin, this adds the bit hacky way to get track number by filename.
+      char section = 0;
+      char track = 0;
+      size_t last_index = std::string::npos;
+      bool check_at_end = false;
+      std::string filename = kodi::vfs::GetFileName(toLoad);
+      if (!isdigit(filename[0]))
+      {
+        filename.resize(filename.size() - 4); // Remove line ending
+        last_index = filename.find_last_not_of("0123456789");
+        if (last_index != std::string::npos)
+        {
+          if (filename.substr(last_index - 1)[0] == '-' && !isdigit(filename.substr(last_index)[0]))
+            section = filename.substr(last_index)[0];
+          track = atoi(filename.substr(last_index + 1).c_str());
+        }
+        check_at_end = true;
+      }
+      else
+      {
+        track = atoi(filename.c_str());
+      }
+
+      if (track > 0)
+      {
+        std::vector<kodi::vfs::CDirEntry> items;
+        if (kodi::vfs::GetDirectory(kodi::vfs::GetDirectoryName(toLoad), ".spc", items) &&
+            items.size() > 1)
+        {
+          bool sorted_dir = true;
+          std::map<char, std::unordered_set<int>> found;
+          for (const auto& entry : items)
+          {
+            if (entry.IsFolder())
+              continue;
+
+            std::string label = entry.Label();
+            char scanSection = 0;
+            char scanTrack = 0;
+            if (!check_at_end)
+            {
+              if (!isdigit(label[0]))
+              {
+                sorted_dir = false;
+                break;
+              }
+
+              scanTrack = atoi(label.c_str());
+            }
+            else
+            {
+              label.resize(label.size() - 4); // Remove line ending
+              size_t last_index = label.find_last_not_of("0123456789");
+              if (last_index != std::string::npos)
+              {
+                if (label.substr(last_index - 1)[0] == '-' && !isdigit(label.substr(last_index)[0]))
+                  scanSection = label.substr(last_index)[0];
+                scanTrack = atoi(label.substr(last_index + 1).c_str());
+                label = label.substr(last_index + 1);
+              }
+              if (!isdigit(label[0]))
+              {
+                sorted_dir = false;
+                break;
+              }
+            }
+
+            if (found[scanSection].find(scanTrack) == found[scanSection].end())
+              found[scanSection].emplace(scanTrack);
+            else
+            {
+              sorted_dir = false;
+              break;
+            }
+          }
+
+          if (sorted_dir)
+          {
+
+            int disc = 1;
+            for (const auto& entry : found)
+            {
+              if (entry.first == section)
+                break;
+              ++disc;
+            }
+
+            tag.SetTrack(track);
+            tag.SetDisc(disc);
+            tag.SetDiscTotal(found.size());
+          }
+        }
+      }
+    }
+  }
+
   tag.SetAlbumArtist(spcTag.publisher);
-  tag.SetTitle(spcTag.song);
   tag.SetAlbum(spcTag.game);
-  tag.SetDuration(spcTag.play_len / SPC_SAMPLERATE / SPC_CHANNELS);
-  tag.SetDisc(spcTag.ost_disc);
-  tag.SetTrack(spcTag.ost_track);
   tag.SetReleaseDate(spcTag.year > 0 ? std::to_string(spcTag.year) : "");
-  tag.SetComment(spcTag.comment);
-  tag.SetSamplerate(SPC_SAMPLERATE);
-  tag.SetChannels(SPC_CHANNELS);
 
   delete[] data;
 
   return true;
+}
+
+int CSPCCodec::TrackCount(const std::string& filename)
+{
+  if (kodi::tools::StringUtils::EndsWith(filename, ".rsn"))
+  {
+    std::vector<kodi::vfs::CDirEntry> items;
+    if (kodi::vfs::GetDirectory("rar://" + URLEncode(filename), ".spc", items))
+      return items.size();
+  }
+
+  return 1;
+}
+
+int CSPCCodec::GetTrackNumber(std::string& toLoad)
+{
+  int track = 0;
+  if (toLoad.rfind("stream") != std::string::npos)
+  {
+    size_t iStart = toLoad.rfind('-') + 1;
+    track = atoi(toLoad.substr(iStart, toLoad.size() - iStart - 10).c_str()) - 1;
+    //  The directory we are in, is the file
+    //  that contains the bitstream to play,
+    //  so extract it
+    size_t slash = toLoad.rfind('\\');
+    if (slash == std::string::npos)
+      slash = toLoad.rfind('/');
+    toLoad = toLoad.substr(0, slash);
+  }
+  return track;
+}
+
+std::string CSPCCodec::URLEncode(const std::string& strURLData)
+{
+  std::string strResult;
+
+  /* wonder what a good value is here is, depends on how often it occurs */
+  strResult.reserve(strURLData.length() * 2);
+
+  for (size_t i = 0; i < strURLData.size(); ++i)
+  {
+    const unsigned char kar = strURLData[i];
+
+    // Don't URL encode "-_.!()" according to RFC1738
+    //! @todo Update it to "-_.~" after Gotham according to RFC3986
+    if (std::isalnum(kar) || kar == '-' || kar == '.' || kar == '_' || kar == '!' || kar == '(' ||
+        kar == ')')
+      strResult.push_back(kar);
+    else
+    {
+      char temp[MAX_PATH_LENGTH];
+      snprintf(temp, MAX_PATH_LENGTH, "%%%2.2X", (unsigned int)((unsigned char)kar));
+      strResult += temp;
+    }
+  }
+
+  return strResult;
 }
 
 //------------------------------------------------------------------------------

--- a/src/SPCCodec.h
+++ b/src/SPCCodec.h
@@ -44,6 +44,7 @@ public:
 private:
   int GetTrackNumber(std::string& toLoad);
   std::string URLEncode(const std::string& strURLData);
+  std::string GetGenre(char idChar);
 
   SPCContext ctx;
 };

--- a/src/SPCCodec.h
+++ b/src/SPCCodec.h
@@ -38,8 +38,12 @@ public:
             std::vector<AudioEngineChannel>& channellist) override;
   int ReadPCM(uint8_t* buffer, int size, int& actualsize) override;
   int64_t Seek(int64_t time) override;
+  int TrackCount(const std::string& filename) override;
   bool ReadTag(const std::string& filename, kodi::addon::AudioDecoderInfoTag& tag) override;
 
 private:
+  int GetTrackNumber(std::string& toLoad);
+  std::string URLEncode(const std::string& strURLData);
+
   SPCContext ctx;
 };


### PR DESCRIPTION
The *.rsn is only a RAR package archive, with this change becomes the track support added.

Also does it add a disc and track check by related file names, where standardized in reference to here http://snesmusic.org/v2/wiki.php?iRequest=wiki/ViewPage&iPage=Rule.